### PR TITLE
Add Intel-based container option for schism forecast step (solve step)

### DIFF
--- a/singularity/scripts/input.conf
+++ b/singularity/scripts/input.conf
@@ -27,6 +27,7 @@ L_SCRIPT_DIR=`realpath ./scripts`
 # Environment
 export SINGULARITY_BINDFLAGS="--bind /lustre"
 export TMPDIR=/lustre/.tmp  # redirect OCSMESH temp files
+export INTEL_SOLVER=0
 
 # Modules
 L_SOLVE_MODULES="openmpi/4.1.2"

--- a/singularity/scripts/schism.sbatch
+++ b/singularity/scripts/schism.sbatch
@@ -5,7 +5,7 @@
 #SBATCH --nodes=3
 #SBATCH --ntasks-per-node=36
 
-module load $MODULES
+if [ $INTEL_SOLVER == 0 ]; then module load $MODULES; fi
 
 export MV2_ENABLE_AFFINITY=0
 ulimit -s unlimited
@@ -14,8 +14,16 @@ set -ex
 
 pushd ${SCHISM_DIR}
 mkdir -p outputs
-mpirun -np 36 singularity exec ${SINGULARITY_BINDFLAGS} ${IMG} \
-    ${SCHISM_EXEC} 4
+
+if [ $INTEL_SOLVER == 1 ]; then
+    export SINGULARITYENV_FI_PROVIDER=tcp
+    export SINGULARITY_SHELL=/bin/bash
+    srun --mpi=pmi2 singularity exec ${SINGULARITY_BINDFLAGS} ${IMG} \
+        ${SCHISM_EXEC} 4
+else
+    mpirun -np 36 singularity exec ${SINGULARITY_BINDFLAGS} ${IMG} \
+        ${SCHISM_EXEC} 4
+fi
 
 if [ $? -eq 0 ]; then
     echo "Combining outputs..."

--- a/singularity/scripts/workflow.sh
+++ b/singularity/scripts/workflow.sh
@@ -104,7 +104,12 @@ setup_id=$(sbatch \
 echo "Launching runs"
 SCHISM_SHARED_ENV=""
 SCHISM_SHARED_ENV+="ALL"
-SCHISM_SHARED_ENV+=",IMG=$L_IMG_DIR/solve.sif"
+if [ $INTEL_SOLVER == 1 ]; then
+    SCHISM_SHARED_ENV+=",IMG=$L_IMG_DIR/solve_intel.sif"
+else
+    SCHISM_SHARED_ENV+=",IMG=$L_IMG_DIR/solve.sif"
+    SCHISM_SHARED_ENV+=",MODULES=$L_SOLVE_MODULES"
+fi
 SCHISM_SHARED_ENV+=",MODULES=$L_SOLVE_MODULES"
 spinup_id=$(sbatch \
     --parsable \


### PR DESCRIPTION
Add an option `INTEL_SOLVER` to `input.conf` so that users can switch to an Intel-based container for the Schism forecast step. The Intel-based image is derived from the [image](https://hub.docker.com/layers/noaaepic/ubuntu20.04-intel-srwapp/release-public-v2.2.0/images/sha256-2511f1d7a0cb7335b0f83762a21e0bb68a4f5a62cb58504c36e31adea722bd28?context=explore) created by NOAA EPIC and an example image can be found at `/lustre/Yi-cheng.Teng/singularity_images/solve_intel.sif`. This draft PR serves as a reference for those interested in running Schism using a container approach with multiple nodes on NOAA RDHPC and CLOUD platforms (e.g. Hera and nhccolab2). Ultimately, we should aim to create our own Intel-based image to reduce the image's size.